### PR TITLE
add MultiThreadEnv

### DIFF
--- a/src/ReinforcementLearningEnvironments.jl
+++ b/src/ReinforcementLearningEnvironments.jl
@@ -11,6 +11,10 @@ include("spaces/spaces.jl")
 # built-in environments
 include("environments/classic_control/classic_control.jl")
 
+if VERSION >= v"1.3.0-rc1"
+    include("multi_thread_env.jl")
+end
+
 # dynamic loading environments
 function __init__()
     @require ArcadeLearningEnvironment = "b7f77d8d-088d-5e02-8ac0-89aab2acc977" include("environments/atari.jl")

--- a/src/multi_thread_env.jl
+++ b/src/multi_thread_env.jl
@@ -1,0 +1,38 @@
+export MultiThreadEnv
+import Base.Threads.@spawn
+
+struct MultiThreadEnv{O, E} <: AbstractEnv
+    envs::Vector{E}
+end
+
+function MultiThreadEnv(f, n)
+    envs = [f() for _ in 1:n]
+    obs = observe(envs[1])
+    MultiThreadEnv{typeof(obs), typeof(envs[1])}(envs)
+end
+
+Base.getindex(env::MultiThreadEnv, i) = getindex(env.envs, i)
+Base.length(env::MultiThreadEnv) = length(env.envs)
+
+function interact!(env::MultiThreadEnv, actions)
+    @sync for i in 1:length(env)
+        @spawn interact!(env[i], actions[i])
+    end
+end
+
+function observe(env::MultiThreadEnv{O, E}) where {O, E}
+    n = length(env)
+    obs = Vector{O}(undef, n)
+    @sync for i in 1:n
+        @spawn begin
+            o = observe(env[i])
+            if o.terminal
+                r, t = o.reward, o.terminal
+                reset!(env[i])
+                first_obs = observe(env[i])
+                o = Observation(r, t, first_obs.state, first_obs.meta)
+            end
+            obs[i] = o
+        end
+    end
+end

--- a/src/multi_thread_env.jl
+++ b/src/multi_thread_env.jl
@@ -35,4 +35,5 @@ function observe(env::MultiThreadEnv{O, E}) where {O, E}
             obs[i] = o
         end
     end
+    obs
 end


### PR DESCRIPTION
Two concerns:

1. The return of `observe(::MultiThreadEnv)` is a vector of `Observation` instead of an `Observation`
1. The inner environments are auto reset during `observe` for performance (otherwise, we need to manually check that if there's any environment terminated after each observation).