### PR TITLE
Fixes to Pendulum.jl and some standardizing of classical control envs

### DIFF
--- a/src/environments/classic_control/mountain_car.jl
+++ b/src/environments/classic_control/mountain_car.jl
@@ -41,7 +41,7 @@ mutable struct MountainCarEnv{A,T,R<:AbstractRNG} <: AbstractEnv
     action_space::A
     observation_space::MultiContinuousSpace{Vector{T}}
     state::Vector{T}
-    action::Int
+    action::Union{Int,AbstractFloat}
     done::Bool
     t::Int
     rng::R
@@ -70,9 +70,10 @@ function MountainCarEnv(; T = Float64, continuous = false, seed = nothing, kwarg
     else
         params = MountainCarEnvParams(; T = T, kwargs...)
     end
+    action_space = continuous ? ContinuousSpace(-T(1.0), T(1.0)) : DiscreteSpace(3)
     env = MountainCarEnv(
         params,
-        continuous ? ContinuousSpace(-T(1.0), T(1.0)) : DiscreteSpace(3),
+        action_space,
         MultiContinuousSpace(
             [params.min_pos, -params.max_speed],
             [params.max_pos, params.max_speed],
@@ -80,7 +81,7 @@ function MountainCarEnv(; T = Float64, continuous = false, seed = nothing, kwarg
         zeros(T, 2),
         1,
         false,
-        0,
+        rand(action_space),
         MersenneTwister(seed),
     )
     reset!(env)
@@ -102,11 +103,19 @@ function RLBase.reset!(env::MountainCarEnv{A,T}) where {A,T}
     nothing
 end
 
-(env::MountainCarEnv{<:ContinuousSpace})(a) = _interact!(env, min(max(a, -1, 1)))
+function (env::MountainCarEnv{<:ContinuousSpace})(a::AbstractFloat)
+    @assert a in env.action_space
+    env.action = a
+    _step!(env, a)
+end
 
-(env::MountainCarEnv{<:DiscreteSpace})(a) = _interact!(env, a - 2)
+function (env::MountainCarEnv{<:DiscreteSpace})(a::Int)
+    @assert a in env.action_space
+    env.action = a
+    _step!(env, a - 2)
+end
 
-function _interact!(env::MountainCarEnv, force)
+function _step!(env::MountainCarEnv, force)
     env.t += 1
     x, v = env.state
     v += force * env.params.power + cos(3 * x) * (-env.params.gravity)

--- a/src/environments/classic_control/mountain_car.jl
+++ b/src/environments/classic_control/mountain_car.jl
@@ -79,9 +79,9 @@ function MountainCarEnv(; T = Float64, continuous = false, seed = nothing, kwarg
             [params.max_pos, params.max_speed],
         ),
         zeros(T, 2),
-        1,
-        false,
         rand(action_space),
+        false,
+        0,
         MersenneTwister(seed),
     )
     reset!(env)

--- a/src/environments/classic_control/pendulum.jl
+++ b/src/environments/classic_control/pendulum.jl
@@ -108,7 +108,6 @@ function _step!(env::PendulumEnv, a)
     th, thdot = env.state
     a = clamp(a, -env.params.max_torque, env.params.max_torque)
     costs = angle_normalize(th)^2 + 0.1 * thdot^2 + 0.001 * a^2
-    a = clamp(a, -env.params.max_torque, env.params.max_torque)
     newthdot =
         thdot +
         (

--- a/src/environments/classic_control/pendulum.jl
+++ b/src/environments/classic_control/pendulum.jl
@@ -12,15 +12,17 @@ struct PendulumEnvParams{T}
     max_steps::Int
 end
 
-mutable struct PendulumEnv{T,R<:AbstractRNG} <: AbstractEnv
+mutable struct PendulumEnv{A,T,R<:AbstractRNG} <: AbstractEnv
     params::PendulumEnvParams{T}
-    action_space::ContinuousSpace
+    action_space::A
     observation_space::MultiContinuousSpace{Vector{T}}
     state::Vector{T}
     done::Bool
     t::Int
     rng::R
     reward::T
+    n_actions::Int
+    action::Union{Int,AbstractFloat}
 end
 
 """
@@ -48,17 +50,22 @@ function PendulumEnv(;
     dt = T(0.05),
     max_steps = 200,
     seed = nothing,
+    continuous::Bool = true,
+    n_actions::Int = 3,
 )
     high = T.([1, 1, max_speed])
+    action_space = continuous ? ContinuousSpace(-2.0, 2.0) : DiscreteSpace(n_actions)
     env = PendulumEnv(
         PendulumEnvParams(max_speed, max_torque, g, m, l, dt, max_steps),
-        ContinuousSpace(-2.0, 2.0),
+        action_space,
         MultiContinuousSpace(-high, high),
         zeros(T, 2),
         false,
         0,
         MersenneTwister(seed),
         zero(T),
+        n_actions,
+        rand(action_space),
     )
     reset!(env)
     env
@@ -67,24 +74,39 @@ end
 Random.seed!(env::PendulumEnv, seed) = Random.seed!(env.rng, seed)
 
 pendulum_observation(s) = [cos(s[1]), sin(s[1]), s[2]]
-angle_normalize(x) = ((x + pi) % (2 * pi)) - pi
+angle_normalize(x) = Base.mod((x + Base.π), (2 * Base.π)) - Base.π
 
 RLBase.observe(env::PendulumEnv) =
     (reward = env.reward, state = pendulum_observation(env.state), terminal = env.done)
 
-function RLBase.reset!(env::PendulumEnv{T}) where {T}
-    env.state[:] = 2 * rand(env.rng, T, 2) .- 1
+function RLBase.reset!(env::PendulumEnv{A,T}) where {A,T}
+    env.state[1] = 2*π*(rand(env.rng, T) .- 1)
+    env.state[2] = 2*(rand(env.rng, T) .- 1)
     env.t = 0
     env.done = false
     env.reward = zero(T)
     nothing
 end
 
-function (env::PendulumEnv)(a)
+function (env::PendulumEnv{<:ContinuousSpace})(a::AbstractFloat)
+    @assert a in env.action_space
+    env.action = a
+    _step!(env, a)
+end
+
+function (env::PendulumEnv{<:DiscreteSpace})(a::Int)
+    @assert a in env.action_space
+    env.action = a
+    float_a = (4 / (env.n_actions - 1)) * (a - (env.n_actions - 1) / 2 - 1)
+    _step!(env, float_a)
+end
+
+function _step!(env::PendulumEnv, a)
     env.t += 1
     th, thdot = env.state
     a = clamp(a, -env.params.max_torque, env.params.max_torque)
     costs = angle_normalize(th)^2 + 0.1 * thdot^2 + 0.001 * a^2
+    a = clamp(a, -env.params.max_torque, env.params.max_torque)
     newthdot =
         thdot +
         (

--- a/src/environments/classic_control/pendulum.jl
+++ b/src/environments/classic_control/pendulum.jl
@@ -26,7 +26,7 @@ mutable struct PendulumEnv{A,T,R<:AbstractRNG} <: AbstractEnv
 end
 
 """
-    PwendulumEnv(;kwargs...)
+    PendulumEnv(;kwargs...)
 
 # Keyword arguments
 
@@ -38,6 +38,8 @@ end
 - `l = T(1)`
 - `dt = T(0.05)`
 - `max_steps = 200`
+- `continuous::Bool = true`
+- `n_actions::Int = 3`
 - `seed = nothing`
 """
 function PendulumEnv(;
@@ -49,9 +51,9 @@ function PendulumEnv(;
     l = T(1),
     dt = T(0.05),
     max_steps = 200,
-    seed = nothing,
     continuous::Bool = true,
     n_actions::Int = 3,
+    seed = nothing,
 )
     high = T.([1, 1, max_speed])
     action_space = continuous ? ContinuousSpace(-2.0, 2.0) : DiscreteSpace(n_actions)


### PR DESCRIPTION
Changes to classical control envs:
 - asserts that action is in the appropriate action_space

Changes to pendulum:
 - angle_normalize now properly normalizes negative thetas.
 - reset! sets the state values as in OpenAI gym
 - Added an option for discrete actions
 - Sets previously used action

Changes to mountain_car:
 - rename _interact! to _step! for consistency
 - Sets previously used action

Changes to cartpole:
 - rename tau to dt for consistency