### PR TITLE
Update RLBase to v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 GR = "0.46, 0.47, 0.48, 0.49, 0.50"
 OrdinaryDiffEq = "5"
-ReinforcementLearningBase = "0.7"
+ReinforcementLearningBase = "0.8"
 Requires = "1.0"
 StatsBase = "0.32, 0.33"
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ By default, only some basic environments are installed. If you want to use some 
 | `AtariEnv` | [ArcadeLearningEnvironment.jl](https://github.com/JuliaReinforcementLearning/ArcadeLearningEnvironment.jl) | Tested only on Linux|
 | `ViZDoomEnv` | [ViZDoom.jl](https://github.com/JuliaReinforcementLearning/ViZDoom.jl) | Currently only a basic environment is supported. (By calling `basic_ViZDoom_env()`)|
 | `GymEnv` | [PyCall.jl](https://github.com/JuliaPy/PyCall.jl) | Tested only on Linux |
-| `MDPEnv`,`POMDPEnv`| [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl)| The `get_observation_space` method is undefined|
+| `MDPEnv`,`POMDPEnv`| [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl)||
 | `OpenSpielEnv` | [OpenSpiel.jl](https://github.com/JuliaReinforcementLearning/OpenSpiel.jl) | |
 
 ## Usage
@@ -46,7 +46,7 @@ julia> using ReinforcementLearningBase
 julia> env = CartPoleEnv()
 CartPoleEnv{Float64}(gravity=9.8,masscart=1.0,masspole=0.1,totalmass=1.1,halflength=0.5,polemasslength=0.05,forcemag=10.0,tau=0.02,thetathreshold=0.20943951023931953,xthreshold=2.4,max_steps=200)
 
-julia> action_space = get_action_space(env)
+julia> action_space = get_actions(env)
 DiscreteSpace{UnitRange{Int64}}(1:2)
 
 julia> while true

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ By default, only some basic environments are installed. If you want to use some 
 - MountainCarEnv
 - ContinuousMountainCarEnv
 - PendulumEnv
+- PendulumNonInteractiveEnv
 
 ### 3-rd Party Environments
 
 | Environment Name | Dependent Package Name | Description |
 | :--- | :--- | :--- |
-| `AtariEnv` | [ArcadeLearningEnvironment.jl](https://github.com/JuliaReinforcementLearning/ArcadeLearningEnvironment.jl) | Tested only on Linux|
-| `ViZDoomEnv` | [ViZDoom.jl](https://github.com/JuliaReinforcementLearning/ViZDoom.jl) | Currently only a basic environment is supported. (By calling `basic_ViZDoom_env()`)|
-| `GymEnv` | [PyCall.jl](https://github.com/JuliaPy/PyCall.jl) | Tested only on Linux |
-| `MDPEnv`,`POMDPEnv`| [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl)||
+| `AtariEnv` | [ArcadeLearningEnvironment.jl](https://github.com/JuliaReinforcementLearning/ArcadeLearningEnvironment.jl) | |
+| `ViZDoomEnv` | [ViZDoom.jl](https://github.com/JuliaReinforcementLearning/ViZDoom.jl) | Broken [help wanted](https://github.com/JuliaReinforcementLearning/ViZDoom.jl/issues/7) |
+| `GymEnv` | [PyCall.jl](https://github.com/JuliaPy/PyCall.jl) | |
+| `MDPEnv`,`POMDPEnv`| [POMDPs.jl](https://github.com/JuliaPOMDP/POMDPs.jl)| Tested with `POMDPs.jl@v0.9`|
 | `OpenSpielEnv` | [OpenSpiel.jl](https://github.com/JuliaReinforcementLearning/OpenSpiel.jl) | |
 
 ## Usage
@@ -44,15 +45,52 @@ julia> using ReinforcementLearningEnvironments
 julia> using ReinforcementLearningBase
 
 julia> env = CartPoleEnv()
-CartPoleEnv{Float64}(gravity=9.8,masscart=1.0,masspole=0.1,totalmass=1.1,halflength=0.5,polemasslength=0.05,forcemag=10.0,tau=0.02,thetathreshold=0.20943951023931953,xthreshold=2.4,max_steps=200)
+# CartPoleEnv
 
-julia> action_space = get_actions(env)
+## Traits
+
+| Trait Type       |                Value |
+|:---------------- | --------------------:|
+| NumAgentStyle    |        SingleAgent() |
+| DynamicStyle     |         Sequential() |
+| InformationStyle | PerfectInformation() |
+| ChanceStyle      |      Deterministic() |
+| RewardStyle      |         StepReward() |
+| UtilityStyle     |         GeneralSum() |
+| ActionStyle      |   MinimalActionSet() |
+
+## Actions
+
+DiscreteSpace{UnitRange{Int64}}(1:2)
+
+## Players
+
+  * `DEFAULT_PLAYER`
+
+## Current Player
+
+`DEFAULT_PLAYER`
+
+## Is Environment Terminated?
+
+No
+
+julia> get_state(env)
+4-element Array{Float64,1}:
+  0.02688439956517477
+ -0.0003235577964125977
+  0.019563124862911535
+ -0.01897808522860225
+
+julia> actions = get_actions(env)
 DiscreteSpace{UnitRange{Int64}}(1:2)
 
 julia> while true
-           action = rand(action_space)
-           env(action)
-           obs = observe(env)
-           get_terminal(obs) && break
+           env(rand(actions))
+           get_terminal(env) && break
        end
 ```
+
+## Application
+
+Checkout [atari.jl](https://github.com/JuliaReinforcementLearning/ReinforcementLearningZoo.jl/blob/master/src/experiments/atari.jl) for some more complicated cases on how to use these environments and the [wrappers](https://github.com/JuliaReinforcementLearning/ReinforcementLearningBase.jl/blob/master/src/implementations/environments.jl) provided in [ReinforcementLearningBase.jl](https://github.com/JuliaReinforcementLearning/ReinforcementLearningBase.jl).

--- a/src/environments/atari.jl
+++ b/src/environments/atari.jl
@@ -151,7 +151,7 @@ function imshowcolor(x::AbstractArray{UInt8,1}, dims)
     updatews()
 end
 
-function render(env::AtariEnv)
+function Base.display(env::AtariEnv)
     x = getScreenRGB(env.ale)
     imshowcolor(x, (Int(getScreenWidth(env.ale)), Int(getScreenHeight(env.ale))))
 end

--- a/src/environments/atari.jl
+++ b/src/environments/atari.jl
@@ -117,8 +117,10 @@ end
 is_terminal(env::AtariEnv{<:Any,true}) = game_over(env.ale) || (lives(env.ale) < env.lives)
 is_terminal(env::AtariEnv{<:Any,false}) = game_over(env.ale)
 
-RLBase.observe(env::AtariEnv) =
-    (reward = env.reward, terminal = is_terminal(env), state = env.screens[1])
+RLBase.get_actions(env::AtariEnv) = env.action_space
+RLBase.get_reward(env::AtariEnv) = env.reward
+RLBase.get_terminal(env::AtariEnv) = is_terminal(env)
+RLBase.get_state(env::AtariEnv) = env.screens[1]
 
 function RLBase.reset!(env::AtariEnv)
     reset_game(env.ale)
@@ -148,7 +150,7 @@ function imshowcolor(x::AbstractArray{UInt8,1}, dims)
     updatews()
 end
 
-function RLBase.render(env::AtariEnv)
+function render(env::AtariEnv)
     x = getScreenRGB(env.ale)
     imshowcolor(x, (Int(getScreenWidth(env.ale)), Int(getScreenHeight(env.ale))))
 end

--- a/src/environments/classic_control/acrobot.jl
+++ b/src/environments/classic_control/acrobot.jl
@@ -119,8 +119,10 @@ end
 
 acrobot_observation(s) = [cos(s[1]), sin(s[1]), cos(s[2]), sin(s[2]), s[3], s[4]]
 
-RLBase.observe(env::AcrobotEnv) =
-    (reward = env.reward, state = acrobot_observation(env.state), terminal = env.done)
+RLBase.get_actions(env::AcrobotEnv) = env.action_space
+RLBase.get_terminal(env::AcrobotEnv) = env.done
+RLBase.get_state(env::AcrobotEnv) = acrobot_observation(env.state)
+RLBase.get_reward(env::AcrobotEnv) = env.reward
 
 function RLBase.reset!(env::AcrobotEnv{T}) where {T<:Number}
     env.state[:] = T(0.1) * rand(env.rng, T, 4) .- T(0.05)

--- a/src/environments/classic_control/acrobot.jl
+++ b/src/environments/classic_control/acrobot.jl
@@ -78,7 +78,7 @@ function AcrobotEnv(;
     g = T(9.8),
     dt = T(0.2),
     max_steps = 200,
-    seed = nothing,
+    rng = Random.GLOBAL_RNG,
     book_or_nips = "book",
     avail_torque = [T(-1.0), T(0.0), T(1.0)],
 )
@@ -108,7 +108,7 @@ function AcrobotEnv(;
         0,
         false,
         0,
-        MersenneTwister(seed),
+        rng,
         T(0.0),
         book_or_nips,
         [T(-1.0), T(0.0), T(1.0)],

--- a/src/environments/classic_control/cartpole.jl
+++ b/src/environments/classic_control/cartpole.jl
@@ -138,7 +138,7 @@ function plotendofepisode(x, y, d)
     end
     return nothing
 end
-function render(env::CartPoleEnv)
+function Base.display(env::CartPoleEnv)
     s, a, d = env.state, env.action, env.done
     x, xdot, theta, thetadot = s
     l = 2 * env.params.halflength

--- a/src/environments/classic_control/cartpole.jl
+++ b/src/environments/classic_control/cartpole.jl
@@ -96,8 +96,10 @@ function RLBase.reset!(env::CartPoleEnv{T}) where {T<:Number}
     nothing
 end
 
-RLBase.observe(env::CartPoleEnv{T}) where {T} =
-    (reward = env.done ? zero(T) : one(T), terminal = env.done, state = env.state)
+RLBase.get_actions(env::CartPoleEnv) = env.action_space
+RLBase.get_reward(env::CartPoleEnv{T}) where {T} = env.done ? zero(T) : one(T)
+RLBase.get_terminal(env::CartPoleEnv) = env.done
+RLBase.get_state(env::CartPoleEnv) = env.state
 
 function (env::CartPoleEnv)(a)
     @assert a in (1, 2)
@@ -136,7 +138,7 @@ function plotendofepisode(x, y, d)
     end
     return nothing
 end
-function RLBase.render(env::CartPoleEnv)
+function render(env::CartPoleEnv)
     s, a, d = env.state, env.action, env.done
     x, xdot, theta, thetadot = s
     l = 2 * env.params.halflength

--- a/src/environments/classic_control/cartpole.jl
+++ b/src/environments/classic_control/cartpole.jl
@@ -45,7 +45,7 @@ Base.show(io::IO, env::CartPoleEnv{T}) where {T} =
 - `forcemag = T(10.0)`
 - `max_steps = 200`
 - 'dt = 0.02'
-- `seed = nothing`
+- `rng = Random.GLOBAL_RNG`
 """
 function CartPoleEnv(;
     T = Float64,
@@ -56,7 +56,7 @@ function CartPoleEnv(;
     forcemag = 10.0,
     max_steps = 200,
     dt = 0.02,
-    seed = nothing,
+    rng = Random.GLOBAL_RNG,
 )
     params = CartPoleEnvParams{T}(
         gravity,
@@ -80,7 +80,7 @@ function CartPoleEnv(;
         2,
         false,
         0,
-        MersenneTwister(seed),
+        rng,
     )
     reset!(cp)
     cp

--- a/src/environments/classic_control/mountain_car.jl
+++ b/src/environments/classic_control/mountain_car.jl
@@ -52,7 +52,7 @@ end
 
 - `T = Float64`
 - `continuous = false`
-- `seed = nothing`
+- `rng = Random.GLOBAL_RNG`
 - `min_pos = -1.2`
 - `max_pos = 0.6`
 - `max_speed = 0.07`
@@ -62,7 +62,7 @@ end
 - `power = 0.001`
 - `gravity = 0.0025`
 """
-function MountainCarEnv(; T = Float64, continuous = false, seed = nothing, kwargs...)
+function MountainCarEnv(; T = Float64, continuous = false, rng = Random.GLOBAL_RNG, kwargs...)
     if continuous
         params = MountainCarEnvParams(; goal_pos = 0.45, power = 0.0015, T = T, kwargs...)
     else
@@ -80,7 +80,7 @@ function MountainCarEnv(; T = Float64, continuous = false, seed = nothing, kwarg
         rand(action_space),
         false,
         0,
-        MersenneTwister(seed),
+        rng,
     )
     reset!(env)
     env

--- a/src/environments/classic_control/mountain_car.jl
+++ b/src/environments/classic_control/mountain_car.jl
@@ -137,7 +137,7 @@ end
 height(xs) = sin(3 * xs) * 0.45 + 0.55
 rotate(xs, ys, θ) = xs * cos(θ) - ys * sin(θ), ys * cos(θ) + xs * sin(θ)
 translate(xs, ys, t) = xs .+ t[1], ys .+ t[2]
-function render(env::MountainCarEnv)
+function Base.display(env::MountainCarEnv)
     s = env.state
     d = env.done
     clearws()

--- a/src/environments/classic_control/mountain_car.jl
+++ b/src/environments/classic_control/mountain_car.jl
@@ -90,8 +90,10 @@ ContinuousMountainCarEnv(; kwargs...) = MountainCarEnv(; continuous = true, kwar
 
 Random.seed!(env::MountainCarEnv, seed) = Random.seed!(env.rng, seed)
 
-RLBase.observe(env::MountainCarEnv) =
-    (reward = env.done ? 0.0 : -1.0, terminal = env.done, state = env.state)
+RLBase.get_actions(env::MountainCarEnv) = env.action_space
+RLBase.get_reward(env::MountainCarEnv{A,T}) where {A, T} = env.done ? zero(T) : -one(T)
+RLBase.get_terminal(env::MountainCarEnv) = env.done
+RLBase.get_state(env::MountainCarEnv) = env.state
 
 function RLBase.reset!(env::MountainCarEnv{A,T}) where {A,T}
     env.state[1] = 0.2 * rand(env.rng, T) - 0.6
@@ -135,7 +137,7 @@ end
 height(xs) = sin(3 * xs) * 0.45 + 0.55
 rotate(xs, ys, θ) = xs * cos(θ) - ys * sin(θ), ys * cos(θ) + xs * sin(θ)
 translate(xs, ys, t) = xs .+ t[1], ys .+ t[2]
-function RLBase.render(env::MountainCarEnv)
+function render(env::MountainCarEnv)
     s = env.state
     d = env.done
     clearws()

--- a/src/environments/classic_control/pendulum.jl
+++ b/src/environments/classic_control/pendulum.jl
@@ -38,7 +38,7 @@ end
 - `max_steps = 200`
 - `continuous::Bool = true`
 - `n_actions::Int = 3`
-- `seed = nothing`
+- `rng = Random.GLOBAL_RNG`
 """
 function PendulumEnv(;
     T = Float64,
@@ -51,7 +51,7 @@ function PendulumEnv(;
     max_steps = 200,
     continuous::Bool = true,
     n_actions::Int = 3,
-    seed = nothing,
+    rng = Random.GLOBAL_RNG
 )
     high = T.([1, 1, max_speed])
     action_space = continuous ? ContinuousSpace(-2.0, 2.0) : DiscreteSpace(n_actions)
@@ -62,7 +62,7 @@ function PendulumEnv(;
         zeros(T, 2),
         false,
         0,
-        MersenneTwister(seed),
+        rng,
         zero(T),
         n_actions,
         rand(action_space),

--- a/src/environments/classic_control/pendulum.jl
+++ b/src/environments/classic_control/pendulum.jl
@@ -76,8 +76,10 @@ Random.seed!(env::PendulumEnv, seed) = Random.seed!(env.rng, seed)
 pendulum_observation(s) = [cos(s[1]), sin(s[1]), s[2]]
 angle_normalize(x) = Base.mod((x + Base.π), (2 * Base.π)) - Base.π
 
-RLBase.observe(env::PendulumEnv) =
-    (reward = env.reward, state = pendulum_observation(env.state), terminal = env.done)
+RLBase.get_actions(env::PendulumEnv) = env.action_space
+RLBase.get_reward(env::PendulumEnv) = env.reward
+RLBase.get_terminal(env::PendulumEnv) = env.done
+RLBase.get_state(env::PendulumEnv) = pendulum_observation(env.state)
 
 function RLBase.reset!(env::PendulumEnv{A,T}) where {A,T}
     env.state[1] = 2 * π * (rand(env.rng, T) .- 1)

--- a/src/environments/gym.jl
+++ b/src/environments/gym.jl
@@ -37,6 +37,7 @@ function GymEnv(name::String)
 end
 
 function (env::GymEnv{T})(action) where {T}
+    env.action_space isa VectSpace && (action = Tuple(action))  # ??? maybe add another TupleSpace
     pycall!(env.state, env.pyenv.step, PyObject, action)
     nothing
 end

--- a/src/environments/gym.jl
+++ b/src/environments/gym.jl
@@ -95,7 +95,7 @@ function Base.convert(::Type{AbstractSpace}, s::PyObject)
             s.nvec .- one(eltype(s.nvec)),
         )
     elseif spacetype == "Tuple"
-        TupleSpace((convert(AbstractSpace, x) for x in s.spaces)...)
+        TupleSpace([convert(AbstractSpace, x) for x in s.spaces])
     elseif spacetype == "Dict"
         DictSpace((k => convert(AbstractSpace, v) for (k, v) in s.spaces)...)
     else

--- a/src/environments/gym.jl
+++ b/src/environments/gym.jl
@@ -75,7 +75,7 @@ function RLBase.get_state(env::GymEnv{T}) where {T}
     end
 end
 
-render(env::GymEnv) = env.pyenv.render()
+Base.display(env::GymEnv) = env.pyenv.render()
 
 ###
 ### utils

--- a/src/environments/gym.jl
+++ b/src/environments/gym.jl
@@ -19,7 +19,7 @@ function GymEnv(name::String)
         Float64
     elseif obs_space isa DiscreteSpace
         Int
-    elseif obs_space isa TupleSpace
+    elseif obs_space isa VectSpace
         PyVector
     elseif obs_space isa DictSpace
         PyDict
@@ -95,7 +95,7 @@ function Base.convert(::Type{AbstractSpace}, s::PyObject)
             s.nvec .- one(eltype(s.nvec)),
         )
     elseif spacetype == "Tuple"
-        TupleSpace([convert(AbstractSpace, x) for x in s.spaces])
+        VectSpace([convert(AbstractSpace, x) for x in s.spaces])
     elseif spacetype == "Dict"
         DictSpace((k => convert(AbstractSpace, v) for (k, v) in s.spaces)...)
     else

--- a/src/environments/gym.jl
+++ b/src/environments/gym.jl
@@ -46,21 +46,36 @@ function RLBase.reset!(env::GymEnv)
     nothing
 end
 
-function RLBase.observe(env::GymEnv{T}) where {T}
+RLBase.get_actions(env::GymEnv) = env.action_space
+
+function RLBase.get_reward(env::GymEnv{T}) where {T}
     if pyisinstance(env.state, PyCall.@pyglobalobj :PyTuple_Type)
         obs, reward, isdone, info = convert(Tuple{T,Float64,Bool,PyDict}, env.state)
-        (reward = reward, terminal = isdone, state = obs)
+        reward
     else
-        # env has just been reseted
-        (
-            reward = 0.0,  # dummy
-            terminal = false,
-            state = convert(T, env.state),
-        )
+        0.0
     end
 end
 
-RLBase.render(env::GymEnv) = env.pyenv.render()
+function RLBase.get_terminal(env::GymEnv{T}) where {T}
+    if pyisinstance(env.state, PyCall.@pyglobalobj :PyTuple_Type)
+        obs, reward, isdone, info = convert(Tuple{T,Float64,Bool,PyDict}, env.state)
+        isdone
+    else
+        false
+    end
+end
+
+function RLBase.get_state(env::GymEnv{T}) where {T}
+    if pyisinstance(env.state, PyCall.@pyglobalobj :PyTuple_Type)
+        obs, reward, isdone, info = convert(Tuple{T,Float64,Bool,PyDict}, env.state)
+        obs
+    else
+        state = convert(T, env.state)
+    end
+end
+
+render(env::GymEnv) = env.pyenv.render()
 
 ###
 ### utils

--- a/src/environments/mdp.jl
+++ b/src/environments/mdp.jl
@@ -1,6 +1,6 @@
 using .POMDPs
 
-RLBase.get_action_space(m::Union{<:POMDP,<:MDP}) = convert(AbstractSpace, actions(m))
+RLBase.get_actions(m::Union{<:POMDP,<:MDP}) = convert(AbstractSpace, actions(m))
 
 #####
 # POMDPEnv
@@ -41,13 +41,9 @@ function (env::POMDPEnv)(a)
     nothing
 end
 
-RLBase.observe(env::POMDPEnv) = (
-    state = env.observation,
-    reward = env.reward,
-    terminal = isterminal(env.model, env.state),
-    inner_state = env.state,
-    info = env.info,
-)
+RLBase.get_state(env::POMDPEnv) = env.observation
+RLBase.get_reward(env::POMDPEnv) = env.reward
+RLBase.get_terminal(env::POMDPEnv) = isterminal(env.model, env.state)
 
 function RLBase.reset!(env::POMDPEnv)
     env.state = initialstate(env.model, env.rng)
@@ -55,8 +51,7 @@ function RLBase.reset!(env::POMDPEnv)
     nothing
 end
 
-RLBase.get_observation_space(env::POMDPEnv) = get_observation_space(env.model)
-RLBase.get_action_space(env::POMDPEnv) = get_action_space(env.model)
+RLBase.get_actions(env::POMDPEnv) = get_actions(env.model)
 
 #####
 # MDPEnv
@@ -95,17 +90,13 @@ function (env::MDPEnv)(a)
     nothing
 end
 
-RLBase.observe(env::MDPEnv) = (
-    state = env.state,
-    reward = env.reward,
-    terminal = isterminal(env.model, env.state),
-    info = env.info,
-)
+RLBase.get_state(env::MDPEnv) = env.state
+RLBase.get_reward(env::MDPEnv) = env.reward
+RLBase.get_terminal(env::MDPEnv) = isterminal(env.model, env.state)
 
 function RLBase.reset!(env::MDPEnv)
     env.state = initialstate(env.model, env.rng)
     nothing
 end
 
-RLBase.get_observation_space(env::MDPEnv) = get_observation_space(env.model)
-RLBase.get_action_space(env::MDPEnv) = get_action_space(env.model)
+RLBase.get_actions(env::MDPEnv) = get_actions(env.model)

--- a/src/environments/mdp.jl
+++ b/src/environments/mdp.jl
@@ -8,8 +8,7 @@ RLBase.get_actions(m::Union{<:POMDP,<:MDP}) = convert(AbstractSpace, actions(m))
 
 Random.seed!(env::POMDPEnv, seed) = Random.seed!(env.rng, seed)
 
-function POMDPEnv(model::POMDP; seed = nothing)
-    rng = MersenneTwister(seed)
+function POMDPEnv(model::POMDP; rng = Random.GLOBAL_RNG)
     s = initialstate(model, rng)
     a = rand(rng, actions(model))
     if :info in nodenames(DDNStructure(model))
@@ -59,8 +58,7 @@ RLBase.get_actions(env::POMDPEnv) = get_actions(env.model)
 
 Random.seed!(env::MDPEnv, seed) = seed!(env.rng, seed)
 
-function MDPEnv(model::MDP; seed = nothing)
-    rng = MersenneTwister(seed)
+function MDPEnv(model::MDP; rng=Random.GLOBAL_RNG)
     s = initialstate(model, rng)
     a = rand(rng, actions(model))
     if :info in nodenames(DDNStructure(model))

--- a/src/environments/mdp.jl
+++ b/src/environments/mdp.jl
@@ -6,95 +6,57 @@ RLBase.get_actions(m::Union{<:POMDP,<:MDP}) = convert(AbstractSpace, actions(m))
 # POMDPEnv
 #####
 
-Random.seed!(env::POMDPEnv, seed) = Random.seed!(env.rng, seed)
-
-function POMDPEnv(model::POMDP; rng = Random.GLOBAL_RNG)
-    s = initialstate(model, rng)
+function POMDPEnv(model::M;rng=Random.GLOBAL_RNG) where M<:POMDP
+    s = rand(rng, initialstate(model))
     a = rand(rng, actions(model))
-    if :info in nodenames(DDNStructure(model))
-        sp, o, r, info = gen(DDNOut(:sp, :o, :r, :info), model, s, a, rng)
-    else
-        (sp, o, r), info = gen(DDNOut(:sp, :o, :r), model, s, a, rng), nothing
-    end
-    env = POMDPEnv(model, sp, o, info, r, rng)
-    reset!(env)
-    env
+    o = rand(rng, initialobs(model, s))
+    POMDPEnv(model, s, a, o, rng)
 end
 
-# no info
-function (env::POMDPEnv{<:POMDP,<:Any,<:Any,<:Nothing,<:Any,<:AbstractRNG})(a)
-    sp, o, r = gen(DDNOut(:sp, :o, :r), env.model, env.state, a, env.rng)
-    env.state = sp
-    env.observation = o
-    env.reward = r
-    nothing
-end
-
-# has info
 function (env::POMDPEnv)(a)
-    sp, o, r, info = gen(DDNOut(:sp, :o, :r, :info), env.model, env.state, a, env.rng)
-    env.state = sp
-    env.observation = o
-    env.info = info
-    env.reward = r
-    nothing
+    env.action = a
+    old_state = env.state
+    env.state = rand(env.rng, transition(env.model, old_state, a))
+    env.observation = rand(env.rng, observation(env.model, old_state, a, env.state))
 end
 
 RLBase.get_state(env::POMDPEnv) = env.observation
-RLBase.get_reward(env::POMDPEnv) = env.reward
+RLBase.get_reward(env::POMDPEnv) = reward(env.state, env.action)
 RLBase.get_terminal(env::POMDPEnv) = isterminal(env.model, env.state)
 
 function RLBase.reset!(env::POMDPEnv)
-    env.state = initialstate(env.model, env.rng)
-    env.observation = initialobs(env.model, env.state, env.rng)
+    env.state = rand(env.rng, initialstate(env.model))
+    env.observation = rand(env.rng, initialobs(env.model, env.state))
     nothing
 end
 
-RLBase.get_actions(env::POMDPEnv) = get_actions(env.model)
+RLBase.get_actions(env::POMDPEnv) = actions(env.model)
+Random.seed!(env::POMDPEnv, seed) = seed!(env.rng, seed)
 
 #####
 # MDPEnv
 #####
 
-Random.seed!(env::MDPEnv, seed) = seed!(env.rng, seed)
-
 function MDPEnv(model::MDP; rng=Random.GLOBAL_RNG)
-    s = initialstate(model, rng)
+    s = rand(rng, initialstate(model))
     a = rand(rng, actions(model))
-    if :info in nodenames(DDNStructure(model))
-        sp, r, info = gen(DDNOut(:sp, :r, :info), model, s, a, rng)
-    else
-        (sp, r), info = gen(DDNOut(:sp, :r), model, s, a, rng), nothing
-    end
-    env = MDPEnv(model, sp, info, r, rng)
-    reset!(env)
-    env
+    MDPEnv(model, s, a, rng)
 end
 
-# no info
-function (env::MDPEnv{<:MDP,<:Any,<:Nothing,<:Any,<:AbstractRNG})(a)
-    sp, r = gen(DDNOut(:sp, :r), env.model, env.state, a, env.rng)
-    env.state = sp
-    env.reward = r
-    nothing
-end
-
-# has info
 function (env::MDPEnv)(a)
-    sp, r, info = gen(DDNOut(:sp, :r, :info), env.model, env.state, a, env.rng)
-    env.state = sp
-    env.info = info
-    env.reward = r
-    nothing
+    env.action = a
+    old_state = env.state
+    env.state = rand(env.rng, transition(env.model, old_state, a))
 end
 
 RLBase.get_state(env::MDPEnv) = env.state
-RLBase.get_reward(env::MDPEnv) = env.reward
+RLBase.get_reward(env::MDPEnv) = reward(env.state, env.action)
 RLBase.get_terminal(env::MDPEnv) = isterminal(env.model, env.state)
 
 function RLBase.reset!(env::MDPEnv)
-    env.state = initialstate(env.model, env.rng)
-    nothing
+    env.state = rand(env.rng, initialstate(env.model))
 end
 
-RLBase.get_actions(env::MDPEnv) = get_actions(env.model)
+RLBase.get_actions(env::MDPEnv) = actions(env.model)
+
+Random.seed!(env::MDPEnv, seed) = seed!(env.rng, seed)

--- a/src/environments/non_interactive/non_interactive.jl
+++ b/src/environments/non_interactive/non_interactive.jl
@@ -2,5 +2,6 @@ export NonInteractiveEnv
 
 abstract type NonInteractiveEnv <: AbstractEnv end
 (env::NonInteractiveEnv)() = env(nothing)
+RLBase.get_actions(::NonInteractiveEnv) = EmptySpace()
 
 include("pendulum.jl")

--- a/src/environments/non_interactive/pendulum.jl
+++ b/src/environments/non_interactive/pendulum.jl
@@ -24,8 +24,6 @@ mutable struct PendulumNonInteractiveEnv{
     R<:AbstractRNG,
 } <: NonInteractiveEnv
     parameters::PendulumNonInteractiveEnvParams{Fl}
-    action_space::EmptySpace
-    observation_space::MultiContinuousSpace{VFl}
     state::VFl
     done::Bool
     t::Int
@@ -43,7 +41,7 @@ end
 - `mass = 1.0`
 - `step_size = 0.01`
 - `maximum_time = 10.0`
-- `seed = nothing`
+- `rng = nothing`
 """
 function PendulumNonInteractiveEnv(;
     float_type = Float64,
@@ -52,7 +50,7 @@ function PendulumNonInteractiveEnv(;
     mass = 1.0,
     step_size = 0.01,
     maximum_time = 10.0,
-    seed = nothing,
+    rng = Random.GLOBAL_RNG,
 )
     parameters = PendulumNonInteractiveEnvParams{float_type}(
         gravity,
@@ -61,18 +59,12 @@ function PendulumNonInteractiveEnv(;
         step_size,
         maximum_time,
     )
-    observation_constraints_lower = [float_type(0), typemin(float_type)]
-    observation_constraints_upper = [float_type(2 * pi), typemax(float_type)]
-    observation_space =
-        MultiContinuousSpace(observation_constraints_lower, observation_constraints_upper)
     env = PendulumNonInteractiveEnv(
         parameters,
-        EmptySpace(),
-        observation_space,
         zeros(float_type, 2),
         false,
         0,
-        MersenneTwister(seed),
+        rng,
     )
     reset!(env)
     env
@@ -80,7 +72,6 @@ end
 
 Random.seed!(env::PendulumNonInteractiveEnv, seed) = Random.seed!(env.rng, seed)
 
-RLBase.get_actions(env::PendulumNonInteractiveEnv) = env.action_space
 RLBase.get_reward(env::PendulumNonInteractiveEnv) = 0
 RLBase.get_terminal(env::PendulumNonInteractiveEnv) = env.done
 RLBase.get_state(env::PendulumNonInteractiveEnv) = env.state

--- a/src/environments/non_interactive/pendulum.jl
+++ b/src/environments/non_interactive/pendulum.jl
@@ -80,9 +80,10 @@ end
 
 Random.seed!(env::PendulumNonInteractiveEnv, seed) = Random.seed!(env.rng, seed)
 
-function RLBase.observe(env::PendulumNonInteractiveEnv)
-    (reward = 0, terminal = env.done, state = env.state)
-end
+RLBase.get_actions(env::PendulumNonInteractiveEnv) = env.action_space
+RLBase.get_reward(env::PendulumNonInteractiveEnv) = 0
+RLBase.get_terminal(env::PendulumNonInteractiveEnv) = env.done
+RLBase.get_state(env::PendulumNonInteractiveEnv) = env.state
 
 function RLBase.reset!(env::PendulumNonInteractiveEnv{Fl}) where {Fl}
     env.state .= (Fl(2 * pi) * rand(env.rng, Fl), randn(env.rng, Fl))

--- a/src/environments/non_interactive/pendulum.jl
+++ b/src/environments/non_interactive/pendulum.jl
@@ -41,7 +41,7 @@ end
 - `mass = 1.0`
 - `step_size = 0.01`
 - `maximum_time = 10.0`
-- `rng = nothing`
+- `rng = Random.GLOBAL_RNG`
 """
 function PendulumNonInteractiveEnv(;
     float_type = Float64,

--- a/src/environments/open_spiel.jl
+++ b/src/environments/open_spiel.jl
@@ -9,6 +9,7 @@ import .OpenSpiel:
     is_chance_node,
     information_state_tensor,
     information_state_tensor_size,
+    information_state_string,
     num_distinct_actions,
     num_players,
     apply_action,
@@ -20,19 +21,22 @@ import .OpenSpiel:
     history,
     observation_tensor_size,
     observation_tensor,
+    observation_string,
     chance_outcomes
 using StatsBase: sample, weights
 
 
 """
-    OpenSpielEnv(name; observation_type=nothing, kwargs...)
+    OpenSpielEnv(name; state_type=nothing, kwargs...)
 
 # Arguments
 
 - `name`::`String`, you can call `ReinforcementLearningEnvironments.OpenSpiel.registered_names()` to see all the supported names. Note that the name can contains parameters, like `"goofspiel(imp_info=True,num_cards=4,points_order=descending)"`. Because the parameters part is parsed by the backend C++ code, the bool variable must be `True` or `False` (instead of `true` or `false`). Another approach is to just specify parameters in `kwargs` in the Julia style.
-- `observation_type`::`Union{Symbol,Nothing}`, Supported values are [`:information`](https://github.com/deepmind/open_spiel/blob/1ad92a54f3b800394b2bc7f178ccdff62d8369e1/open_spiel/spiel.h#L342-L367), [`:observation`](https://github.com/deepmind/open_spiel/blob/1ad92a54f3b800394b2bc7f178ccdff62d8369e1/open_spiel/spiel.h#L397-L408) or `nothing`. The default value is `nothing`, which means `:information` if the game ` provides_information_state_tensor`. If not, it means `:observation`.
+- `state_type`::`Union{Symbol,Nothing}`, Supported values are [`:information`](https://github.com/deepmind/open_spiel/blob/1ad92a54f3b800394b2bc7f178ccdff62d8369e1/open_spiel/spiel.h#L342-L367), [`:observation`](https://github.com/deepmind/open_spiel/blob/1ad92a54f3b800394b2bc7f178ccdff62d8369e1/open_spiel/spiel.h#L397-L408) or `nothing`. The default value is `nothing`, which means `:information` if the game ` provides_information_state_tensor`. If not, it means `:observation`.
+- `seed::Int`, used to initial the internal `rng`. And the `rng` will only be used if the environment contains chance node, else it is set to `nothing`.
+- `is_chance_agent_required::Bool=false`, by default, no chance agent is required. An internal `rng` will be used to automatically generate actions for chance node. If set to `true`, you need to feed the action of chance agent to environment explicitly. And the `seed` will be ignored.
 """
-function OpenSpielEnv(name; seed = nothing, observation_type = nothing, kwargs...)
+function OpenSpielEnv(name; seed = nothing, state_type= nothing, is_chance_agent_required=false, kwargs...)
     game = load_game(name, kwargs...)
     game_type = get_type(game)
 
@@ -41,17 +45,17 @@ function OpenSpielEnv(name; seed = nothing, observation_type = nothing, kwargs..
     has_info_state ||
         has_obs_state ||
         @error "the environment neither provides information tensor nor provides observation tensor"
-    if isnothing(observation_type)
-        observation_type = has_info_state ? :information : :observation
+    if isnothing(state_type)
+        state_type= has_info_state ? :information : :observation
     end
-    if observation_type == :observation
+    if state_type== :observation
         has_obs_state ||
-            @error "the environment doesn't support observation_type of $observation_type"
-    elseif observation_type == :information
+            @error "the environment doesn't support state_typeof $state_type"
+    elseif state_type== :information
         has_info_state ||
-            @error "the environment doesn't support observation_type of $observation_type"
+            @error "the environment doesn't support state_typeof $state_type"
     else
-        @error "unknown observation_type $observation_type"
+        @error "unknown state_type $state_type"
     end
 
     d = dynamics(game_type)
@@ -72,7 +76,7 @@ function OpenSpielEnv(name; seed = nothing, observation_type = nothing, kwargs..
     end
 
     env =
-        OpenSpielEnv{observation_type,dynamic_style,typeof(state),typeof(game),typeof(rng)}(
+        OpenSpielEnv{state_type,dynamic_style,typeof(state),typeof(game),typeof(rng),is_chance_agent_required}(
             state,
             game,
             rng,
@@ -81,15 +85,23 @@ function OpenSpielEnv(name; seed = nothing, observation_type = nothing, kwargs..
     env
 end
 
-Base.copy(env::OpenSpielEnv{O,D,S,G,R}) where {O,D,S,G,R} =
-    OpenSpielEnv{O,D,S,G,R}(copy(env.state), env.game, env.rng)
+is_chance_agent_required(env::OpenSpielEnv{O,D,S,G,R,C}) where {O,D,S,G,R,C} = C
+
+Base.copy(env::OpenSpielEnv{O,D,S,G,R,C}) where {O,D,S,G,R,C} =
+    OpenSpielEnv{O,D,S,G,R,C}(copy(env.state), env.game, env.rng)
 Base.show(io::IO, env::OpenSpielEnv) = show(io, env.state)
+Base.show(io::IO, obs::OpenSpielObs) = show(io, obs.state)
 
 RLBase.DynamicStyle(env::OpenSpielEnv{O,D}) where {O,D} = D
 
 function RLBase.reset!(env::OpenSpielEnv)
     state = new_initial_state(env.game)
-    _sample_external_events!(env.rng, state)
+    is_chance_agent_required(env) || _sample_external_events!(env.rng, state)
+    env.state = state
+end
+
+function RLBase.reset!(env::OpenSpielEnv, state)
+    is_chance_agent_required(env) || _sample_external_events!(env.rng, state)
     env.state = state
 end
 
@@ -106,7 +118,7 @@ end
 
 function (env::OpenSpielEnv)(action)
     apply_action(env.state, action)
-    _sample_external_events!(env.rng, env.state)
+    is_chance_agent_required(env) || _sample_external_events!(env.rng, env.state)
 end
 
 (env::OpenSpielEnv)(player, action) = env(DynamicStyle(env), player, action)
@@ -117,7 +129,7 @@ function (env::OpenSpielEnv)(::Sequential, player, action)
     else
         apply_action(env.state, OpenSpiel.INVALID_ACTION[])
     end
-    _sample_external_events!(env.rng, env.state)
+    is_chance_agent_required(env) || _sample_external_events!(env.rng, env.state)
 end
 
 (env::OpenSpielEnv)(::Simultaneous, player, action) =
@@ -140,9 +152,8 @@ function RLBase.get_observation_space(env::OpenSpielEnv{:observation})
 end
 
 RLBase.get_current_player(env::OpenSpielEnv) = current_player(env.state)
-RLBase.get_player_id(env::OpenSpielEnv) = get_current_player(env) + 1
-
-RLBase.get_num_players(env::OpenSpielEnv) = num_players(env.game)
+RLBase.get_chance_player(env::OpenSpielEnv) = convert(Int, OpenSpiel.CHANCE_PLAYER)
+RLBase.get_players(env::OpenSpielEnv) = 0:(num_players(env.game)-1)
 
 Random.seed!(env::OpenSpielEnv, seed) = Random.seed!(env.rng, seed)
 
@@ -150,18 +161,39 @@ RLBase.ActionStyle(::OpenSpielObs) = FULL_ACTION_SET
 
 RLBase.get_legal_actions(obs::OpenSpielObs) = legal_actions(obs.state, obs.player)
 
-RLBase.get_legal_actions_mask(obs::OpenSpielObs) = legal_actions_mask(obs.state, obs.player)
+RLBase.get_legal_actions_mask(obs::OpenSpielObs) = convert(Vector{Bool}, legal_actions_mask(obs.state, obs.player))
 
 RLBase.get_terminal(obs::OpenSpielObs) = OpenSpiel.is_terminal(obs.state)
 
 RLBase.get_reward(obs::OpenSpielObs) = player_reward(obs.state, obs.player)
 RLBase.get_reward(env::OpenSpielEnv) = rewards(env.state)
 
-RLBase.get_state(obs::OpenSpielObs{:information}) =
-    information_state_tensor(obs.state, obs.player)
+function RLBase.get_state(obs::OpenSpielObs{:information})
+    if obs.player >=0
+        information_state_tensor(obs.state, obs.player)
+    else
+        # OpenSpiel doesn't allow getting information for chance nodes
+        nothing
+    end
+end
+
+function RLBase.get_state_str(obs::OpenSpielObs{:information})
+    if obs.player >=0
+        information_state_string(obs.state, obs.player)
+    else
+        # OpenSpiel doesn't allow getting information for chance nodes
+        ""
+    end
+end
 
 RLBase.get_state(obs::OpenSpielObs{:observation}) =
     observation_tensor(obs.state, obs.player)
 
+RLBase.get_state_str(obs::OpenSpielObs{:observation}) =
+    observation_string(obs.state, obs.player)
+
+RLBase.get_env_state(obs::OpenSpielObs) = obs.state
+RLBase.get_chance_outcome(obs::OpenSpielObs) = chance_outcomes(obs.state)
+RLBase.get_history(obs::OpenSpielObs) = history(obs.state)
 RLBase.get_history(obs::OpenSpielObs) = history(obs.state)
 RLBase.get_history(env::OpenSpielEnv) = history(env.state)

--- a/src/environments/open_spiel.jl
+++ b/src/environments/open_spiel.jl
@@ -171,5 +171,6 @@ function RLBase.get_reward(env::OpenSpielEnv, player)
 end
 
 RLBase.get_state(env::OpenSpielEnv) = env.state
+RLBase.get_state(env::OpenSpielEnv, player::Integer) = env.state
 
 RLBase.get_history(env::OpenSpielEnv) = history(env.state)

--- a/src/environments/structs.jl
+++ b/src/environments/structs.jl
@@ -16,7 +16,7 @@ mutable struct AtariEnv{IsGrayScale,TerminalOnLifeLoss,N,S<:AbstractRNG} <: Abst
     frame_skip::Int
     reward::Float32
     lives::Int
-    seed::S
+    rng::S
 end
 export AtariEnv
 

--- a/src/environments/structs.jl
+++ b/src/environments/structs.jl
@@ -39,8 +39,8 @@ mutable struct MDPEnv{M,S,I,R,RNG<:AbstractRNG} <: AbstractEnv
 end
 export MDPEnv
 
-mutable struct OpenSpielEnv{O,D,S,G,R,C} <: AbstractEnv
-    state::S
+mutable struct OpenSpielEnv{S,T,ST,G,R} <: AbstractEnv
+    state::ST
     game::G
     rng::R
 end

--- a/src/environments/structs.jl
+++ b/src/environments/structs.jl
@@ -21,22 +21,20 @@ mutable struct AtariEnv{IsGrayScale,TerminalOnLifeLoss,N,S<:AbstractRNG} <: Abst
 end
 export AtariEnv
 
-mutable struct POMDPEnv{M,S,O,I,R,RNG<:AbstractRNG} <: AbstractEnv
+mutable struct POMDPEnv{M,S,A,O,R} <: AbstractEnv
     model::M
     state::S
+    action::A
     observation::O
-    info::I
-    reward::R
-    rng::RNG
+    rng::R
 end
 export POMDPEnv
 
-mutable struct MDPEnv{M,S,I,R,RNG<:AbstractRNG} <: AbstractEnv
+mutable struct MDPEnv{M,S,A,R} <: AbstractEnv
     model::M
     state::S
-    info::I
-    reward::R
-    rng::RNG
+    action::A
+    rng::R
 end
 export MDPEnv
 

--- a/src/environments/structs.jl
+++ b/src/environments/structs.jl
@@ -8,6 +8,7 @@ export GymEnv
 
 mutable struct AtariEnv{IsGrayScale,TerminalOnLifeLoss,N,S<:AbstractRNG} <: AbstractEnv
     ale::Ptr{Nothing}
+    name::String
     screens::Tuple{Array{UInt8,N},Array{UInt8,N}}  # for max-pooling
     actions::Vector{Int}
     action_space::DiscreteSpace{UnitRange{Int}}

--- a/src/environments/structs.jl
+++ b/src/environments/structs.jl
@@ -45,8 +45,3 @@ mutable struct OpenSpielEnv{O,D,S,G,R,C} <: AbstractEnv
     rng::R
 end
 export OpenSpielEnv
-
-struct OpenSpielObs{O,D,S}
-    state::S
-    player::Int32
-end

--- a/src/environments/structs.jl
+++ b/src/environments/structs.jl
@@ -39,7 +39,7 @@ mutable struct MDPEnv{M,S,I,R,RNG<:AbstractRNG} <: AbstractEnv
 end
 export MDPEnv
 
-mutable struct OpenSpielEnv{O,D,S,G,R} <: AbstractEnv
+mutable struct OpenSpielEnv{O,D,S,G,R,C} <: AbstractEnv
     state::S
     game::G
     rng::R

--- a/test/atari.jl
+++ b/test/atari.jl
@@ -1,6 +1,6 @@
 @testset "atari" begin
     @testset "seed" begin
-        env = AtariEnv(; name = "pong", seed = (123, 456))
+        env = AtariEnv(; name = "pong", seed = 456, rng=MersenneTwister(789))
         old_states = []
         actions = [rand(get_actions(env)) for i in 1:10, j in 1:100]
 
@@ -12,7 +12,7 @@
             reset!(env)
         end
 
-        env = AtariEnv(; name = "pong", seed = (123, 456))
+        env = AtariEnv(; name = "pong", seed = 456, rng=MersenneTwister(789))
         new_states = []
         for i in 1:10
             for j in 1:100
@@ -26,7 +26,7 @@
     end
 
     @testset "frame_skip" begin
-        env = AtariEnv(; name = "pong", frame_skip = 4, seed = (123, 456))
+        env = AtariEnv(; name = "pong", frame_skip = 4, seed = 456, rng=MersenneTwister(789))
         states = []
         actions = [rand(get_actions(env)) for _ in 1:100]
 
@@ -35,7 +35,7 @@
             push!(states, copy(get_state(env)))
         end
 
-        env = AtariEnv(; name = "pong", frame_skip = 1, seed = (123, 456))
+        env = AtariEnv(; name = "pong", frame_skip = 1, seed = 456, rng=MersenneTwister(789))
         for i in 1:100
             env(actions[i])
             env(actions[i])
@@ -48,7 +48,7 @@
     end
 
     @testset "repeat_action_probability" begin
-        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = (123, 456))
+        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = 456, rng=MersenneTwister(789))
         states = []
         actions = [rand(get_actions(env)) for _ in 1:100]
         for i in 1:100
@@ -56,7 +56,7 @@
             push!(states, copy(get_state(env)))
         end
 
-        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = (123, 456))
+        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = 456, rng=MersenneTwister(789))
         for i in 1:100
             env(actions[1])
             @test states[i] == get_state(env)
@@ -66,7 +66,7 @@
     @testset "max_num_frames_per_episode" begin
         for i in 1:10
             env =
-                AtariEnv(; name = "pong", max_num_frames_per_episode = i, seed = (123, 456))
+                AtariEnv(; name = "pong", max_num_frames_per_episode = i, seed = 456, rng=MersenneTwister(789))
             for _ in 1:i
                 env(1)
             end

--- a/test/atari.jl
+++ b/test/atari.jl
@@ -1,6 +1,6 @@
 @testset "atari" begin
     @testset "seed" begin
-        env = AtariEnv(; name = "pong", seed = 456, rng=MersenneTwister(789))
+        env = AtariEnv(; name = "pong", seed = 456)
         old_states = []
         actions = [rand(get_actions(env)) for i in 1:10, j in 1:100]
 
@@ -12,7 +12,7 @@
             reset!(env)
         end
 
-        env = AtariEnv(; name = "pong", seed = 456, rng=MersenneTwister(789))
+        env = AtariEnv(; name = "pong", seed = 456)
         new_states = []
         for i in 1:10
             for j in 1:100
@@ -26,7 +26,7 @@
     end
 
     @testset "frame_skip" begin
-        env = AtariEnv(; name = "pong", frame_skip = 4, seed = 456, rng=MersenneTwister(789))
+        env = AtariEnv(; name = "pong", frame_skip = 4, seed = 456)
         states = []
         actions = [rand(get_actions(env)) for _ in 1:100]
 
@@ -35,7 +35,7 @@
             push!(states, copy(get_state(env)))
         end
 
-        env = AtariEnv(; name = "pong", frame_skip = 1, seed = 456, rng=MersenneTwister(789))
+        env = AtariEnv(; name = "pong", frame_skip = 1, seed = 456)
         for i in 1:100
             env(actions[i])
             env(actions[i])
@@ -48,7 +48,7 @@
     end
 
     @testset "repeat_action_probability" begin
-        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = 456, rng=MersenneTwister(789))
+        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = 456)
         states = []
         actions = [rand(get_actions(env)) for _ in 1:100]
         for i in 1:100
@@ -56,7 +56,7 @@
             push!(states, copy(get_state(env)))
         end
 
-        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = 456, rng=MersenneTwister(789))
+        env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = 456)
         for i in 1:100
             env(actions[1])
             @test states[i] == get_state(env)
@@ -66,7 +66,7 @@
     @testset "max_num_frames_per_episode" begin
         for i in 1:10
             env =
-                AtariEnv(; name = "pong", max_num_frames_per_episode = i, seed = 456, rng=MersenneTwister(789))
+                AtariEnv(; name = "pong", max_num_frames_per_episode = i, seed = 456)
             for _ in 1:i
                 env(1)
             end

--- a/test/atari.jl
+++ b/test/atari.jl
@@ -2,12 +2,12 @@
     @testset "seed" begin
         env = AtariEnv(; name = "pong", seed = (123, 456))
         old_states = []
-        actions = [rand(get_action_space(env)) for i in 1:10, j in 1:100]
+        actions = [rand(get_actions(env)) for i in 1:10, j in 1:100]
 
         for i in 1:10
             for j in 1:100
                 env(actions[i, j])
-                push!(old_states, copy(observe(env).state))
+                push!(old_states, copy(get_state(env)))
             end
             reset!(env)
         end
@@ -17,7 +17,7 @@
         for i in 1:10
             for j in 1:100
                 env(actions[i, j])
-                push!(new_states, copy(observe(env).state))
+                push!(new_states, copy(get_state(env)))
             end
             reset!(env)
         end
@@ -28,11 +28,11 @@
     @testset "frame_skip" begin
         env = AtariEnv(; name = "pong", frame_skip = 4, seed = (123, 456))
         states = []
-        actions = [rand(get_action_space(env)) for _ in 1:100]
+        actions = [rand(get_actions(env)) for _ in 1:100]
 
         for i in 1:100
             env(actions[i])
-            push!(states, copy(observe(env).state))
+            push!(states, copy(get_state(env)))
         end
 
         env = AtariEnv(; name = "pong", frame_skip = 1, seed = (123, 456))
@@ -40,9 +40,9 @@
             env(actions[i])
             env(actions[i])
             env(actions[i])
-            s1 = copy(observe(env).state)
+            s1 = copy(get_state(env))
             env(actions[i])
-            s2 = copy(observe(env).state)
+            s2 = copy(get_state(env))
             @test states[i] == max.(s1, s2)
         end
     end
@@ -50,16 +50,16 @@
     @testset "repeat_action_probability" begin
         env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = (123, 456))
         states = []
-        actions = [rand(get_action_space(env)) for _ in 1:100]
+        actions = [rand(get_actions(env)) for _ in 1:100]
         for i in 1:100
             env(actions[i])
-            push!(states, copy(observe(env).state))
+            push!(states, copy(get_state(env)))
         end
 
         env = AtariEnv(; name = "pong", repeat_action_probability = 1.0, seed = (123, 456))
         for i in 1:100
             env(actions[1])
-            @test states[i] == observe(env).state
+            @test states[i] == get_state(env)
         end
     end
 
@@ -70,7 +70,7 @@
             for _ in 1:i
                 env(1)
             end
-            @test true == observe(env).terminal
+            @test true == get_terminal(env)
         end
     end
 end

--- a/test/environments.jl
+++ b/test/environments.jl
@@ -2,9 +2,7 @@
 
     function basic_env_test(env, n = 100)
         reset!(env)
-        observation_space = get_observation_space(env)
-        action_space = get_action_space(env)
-        @test observation_space isa AbstractSpace
+        action_space = get_actions(env)
         @test action_space isa AbstractSpace
         @test reset!(env) == nothing
         for _ in 1:n
@@ -12,7 +10,6 @@
             @test a in action_space
             @test env(a) === nothing
             obs = observe(env)
-            @test get_state(obs) in observation_space
             if get_terminal(obs)
                 reset!(env)
             end
@@ -31,7 +28,7 @@
     gym_env_names = filter(x -> x != "KellyCoinflipGeneralized-v0", gym_env_names)  # not sure why this env has outliers
 
     atari_env_names = ReinforcementLearningEnvironments.list_atari_rom_names()
-    atari_env_names = filter(x -> x != "defender", atari_env_names)
+    atari_env_names = filter(x -> x ∉ ["pacman", "surround"], atari_env_names)
 
     for env_exp in [
         # :(basic_ViZDoom_env()),  # comment out due to https://github.com/JuliaReinforcementLearning/ViZDoom.jl/issues/7

--- a/test/environments.jl
+++ b/test/environments.jl
@@ -3,12 +3,10 @@
     function basic_env_test(env, n = 100)
         reset!(env)
         action_space = get_actions(env)
-        @test action_space isa AbstractSpace
-        @test reset!(env) == nothing
         for _ in 1:n
             a = rand(action_space)
             @test a in action_space
-            @test env(a) === nothing
+            env(a)
             if get_terminal(env)
                 reset!(env)
             end
@@ -32,6 +30,7 @@
     for env_exp in [
         # :(basic_ViZDoom_env()),  # comment out due to https://github.com/JuliaReinforcementLearning/ViZDoom.jl/issues/7
         :(POMDPEnv(TigerPOMDP())),
+        :(MDPEnv(MountainCar())),
         :(MountainCarEnv()),
         :(ContinuousMountainCarEnv()),
         :(AcrobotEnv()),

--- a/test/environments.jl
+++ b/test/environments.jl
@@ -9,8 +9,7 @@
             a = rand(action_space)
             @test a in action_space
             @test env(a) === nothing
-            obs = observe(env)
-            if get_terminal(obs)
+            if get_terminal(env)
                 reset!(env)
             end
         end

--- a/test/open_spiel.jl
+++ b/test/open_spiel.jl
@@ -32,6 +32,7 @@
             get_terminal(env) && break
             action = rand(get_legal_actions(obs))
             env(action)
+            obs = observe(env)
         end
         @test true
     end

--- a/test/open_spiel.jl
+++ b/test/open_spiel.jl
@@ -6,33 +6,31 @@
         "goofspiel(imp_info=True,num_cards=4,points_order=descending)",
     ]
         @info "testing OpenSpiel: $name"
-        env = OpenSpielEnv(name, seed = 123)
+        env = OpenSpielEnv(name)
         get_current_player(env)
         get_actions(env)
         DynamicStyle(env)
 
-        obs = observe(env)
-        obs_0 = observe(env, 0)
-        obs_1 = observe(env, 1)
-        ActionStyle(obs_0)
-        get_legal_actions_mask(obs_0)
-        get_legal_actions_mask(obs_1)
-        get_legal_actions(obs_0)
-        get_legal_actions(obs_1)
-        get_terminal(obs_0)
-        get_terminal(obs_1)
-        get_reward(obs_0)
-        get_reward(obs_1)
-        get_state(obs_0)
-        get_state(obs_1)
+        env_0 = SubjectiveEnv(env, 0)
+        env_1 = SubjectiveEnv(env, 1)
+        ActionStyle(env_0)
+        get_legal_actions_mask(env_0)
+        get_legal_actions_mask(env_1)
+        get_legal_actions(env_0)
+        get_legal_actions(env_1)
+        get_terminal(env_0)
+        get_terminal(env_1)
+        get_reward(env_0)
+        get_reward(env_1)
+        get_state(env_0)
+        get_state(env_1)
 
         reset!(env)
 
         while true
             get_terminal(env) && break
-            action = rand(get_legal_actions(obs))
+            action = rand(get_legal_actions(env))
             env(action)
-            obs = observe(env)
         end
         @test true
     end

--- a/test/open_spiel.jl
+++ b/test/open_spiel.jl
@@ -5,10 +5,10 @@
         "kuhn_poker",
         "goofspiel(imp_info=True,num_cards=4,points_order=descending)",
     ]
+        @info "testing OpenSpiel: $name"
         env = OpenSpielEnv(name, seed = 123)
         get_current_player(env)
-        get_observation_space(env)
-        get_action_space(env)
+        get_actions(env)
         DynamicStyle(env)
 
         obs = observe(env)
@@ -29,8 +29,7 @@
         reset!(env)
 
         while true
-            obs = observe(env)
-            get_terminal(obs) && break
+            get_terminal(env) && break
             action = rand(get_legal_actions(obs))
             env(action)
         end

--- a/test/open_spiel.jl
+++ b/test/open_spiel.jl
@@ -7,7 +7,6 @@
     ]
         env = OpenSpielEnv(name, seed = 123)
         get_current_player(env)
-        get_num_players(env)
         get_observation_space(env)
         get_action_space(env)
         DynamicStyle(env)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,6 @@ using POMDPModels
 using OpenSpiel
 using Random
 
-RLBase.get_observation_space(m::TigerPOMDP) = DiscreteSpace((false, true))
-
 @testset "ReinforcementLearningEnvironments" begin
 
     include("environments.jl")


### PR DESCRIPTION
# Changes

## RLBase related

- `TupleSpace` -> `VectSpace`
- `observe` removed
- `render` -> `Base.display`

## Misc

- use `rng` instead of `seed` if possible
- `POMDPs` updated to v0.9
- Traits of `OpenSpielEnv` are updated

## What's missing?

- [ ] The `get_state(env::OpenSpielEnv)` needs to be expanded to several possible kinds of states. Will be added in the next patch release together with some use cases.