### PR TITLE
reset current_t upon resetting MaxTimeoutEnv

### DIFF
--- a/src/environments/wrappers/MaxTimeoutEnv.jl
+++ b/src/environments/wrappers/MaxTimeoutEnv.jl
@@ -29,7 +29,7 @@ end
 RLBase.is_terminated(env::MaxTimeoutEnv) =
     (env.current_t > env.max_t) || is_terminated(env.env)
 
-function RLBase.reset!(env::MyMaxTimeoutEnv)
+function RLBase.reset!(env::MaxTimeoutEnv)
     env.current_t = 1
     RLBase.reset!(env.env)
 end

--- a/src/environments/wrappers/MaxTimeoutEnv.jl
+++ b/src/environments/wrappers/MaxTimeoutEnv.jl
@@ -20,7 +20,7 @@ function (env::MaxTimeoutEnv)(args...; kwargs...)
 end
 
 for f in vcat(RLBase.ENV_API, RLBase.MULTI_AGENT_ENV_API)
-    if f != :terminal
+    if f ∉ (:is_terminated, :reset!)
         @eval RLBase.$f(x::MaxTimeoutEnv, args...; kwargs...) =
             $f(x.env, args...; kwargs...)
     end
@@ -29,6 +29,10 @@ end
 RLBase.is_terminated(env::MaxTimeoutEnv) =
     (env.current_t > env.max_t) || is_terminated(env.env)
 
+function RLBase.reset!(env::MyMaxTimeoutEnv)
+    env.current_t = 1
+    RLBase.reset!(env.env)
+end
 
 RLBase.state(env::MaxTimeoutEnv, ss::RLBase.AbstractStateStyle) = state(env.env, ss)
 RLBase.state_space(env::MaxTimeoutEnv, ss::RLBase.AbstractStateStyle) =

--- a/test/environments/wrappers/wrappers.jl
+++ b/test/environments/wrappers/wrappers.jl
@@ -37,6 +37,9 @@
             n -= 1
             @test n >= 0
         end
+
+        RLBase.reset!(env′)
+        @test env′.current_t == 1
     end
 
     @testset "RewardOverriddenEnv" begin

--- a/test/environments/wrappers/wrappers.jl
+++ b/test/environments/wrappers/wrappers.jl
@@ -38,8 +38,9 @@
             @test n >= 0
         end
 
-        RLBase.reset!(env′)
+        reset!(env′)
         @test env′.current_t == 1
+        @test is_terminated(env′) == false
     end
 
     @testset "RewardOverriddenEnv" begin


### PR DESCRIPTION
Fix bug
1. reset `current_t` upon each `reset!` of `MaxTimeoutEnv`
See [https://github.com/JuliaReinforcementLearning/ReinforcementLearningBase.jl/pull/102](https://github.com/JuliaReinforcementLearning/ReinforcementLearningBase.jl/pull/102).

2. Also, change `:terminal` to `:is_terminated`, which is the name of the method that returns whether and environment has terminated or not.