### PR TITLE
Fixed Acrobot Rewards

### DIFF
--- a/src/environments/3rd_party/AcrobotEnv.jl
+++ b/src/environments/3rd_party/AcrobotEnv.jl
@@ -86,6 +86,7 @@ function RLBase.reset!(env::AcrobotEnv{T}) where {T <: Number}
     env.t = 0
     env.action = 2
     env.done = false
+    env.reward = -1
     nothing
 end
 

--- a/src/environments/3rd_party/AcrobotEnv.jl
+++ b/src/environments/3rd_party/AcrobotEnv.jl
@@ -117,8 +117,9 @@ function (env::AcrobotEnv{T})(a) where {T <: Number}
     ns[4] = bound(ns[4], -env.params.max_vel_b, env.params.max_vel_b)
     env.state = ns
     # termination criterion
-    env.done = (-cos(ns[1]) - cos(ns[2] + ns[1]) > 1.0) || env.t > env.params.max_steps
-    env.reward = env.done ? -1.0 : 0.0
+    succeeded = -cos(ns[1]) - cos(ns[2] + ns[1]) > 1.0
+    env.done = succeeded || env.t > env.params.max_steps
+    env.reward = succeeded ? 0.0 : -1.0
     nothing
 end
 


### PR DESCRIPTION
This fixes 3 potential bugs with AcrobotEnv.
1. Previously, reward was 0 until success, at which point the reward was set to -1. This is the opposite of the [desired behavior](https://github.com/openai/gym/blob/a5a6ae6bc0a5cfc0ff1ce9be723d59593c165022/gym/envs/classic_control/acrobot.py#L129-L130), since it discourages the agent from success. This sets the reward to -1 until success, and success now yields a reward of 0.
2. The reward was previously set whenever the environment finished, whether by exceeding `max_steps` or by having the agent succeed. Thus, whenever `max_steps` terminated the environment before the `stop_condition`, it didn't really matter whether or not the agent did anything - the reward would be the same no matter what. Now the reward is only set when the agent succeeds.
3. The reward is maintained as `env.reward`, and was previously only set in `(env::AcrobotEnv{T})(a)`. Therefore, before the very first action, the reward might be incorrect. If the `PRE_EPISODE_STAGE` policy or hook happened to depend on the reward, this could lead to odd behavior. Now the reward is reset to `-1` on `reset!`. 