### PR TITLE
Update wrappers

### DIFF
--- a/src/environments/wrappers/ActionTransformedEnv.jl
+++ b/src/environments/wrappers/ActionTransformedEnv.jl
@@ -21,6 +21,13 @@ function ActionTransformedEnv(
     ActionTransformedEnv(action_space_mapping, action_mapping, env)
 end
 
+function ActionTransformedEnv(;
+    action_space_mapping = identity,
+    action_mapping = identity,
+)
+    env -> ActionTransformedEnv(action_space_mapping, action_mapping, env)
+end
+
 RLBase.action_space(env::ActionTransformedEnv, args...) =
     env.action_space_mapping(action_space(env.env), args...)
 

--- a/src/environments/wrappers/RewardOverriddenEnv.jl
+++ b/src/environments/wrappers/RewardOverriddenEnv.jl
@@ -1,5 +1,10 @@
 export RewardOverriddenEnv
 
+"""
+    RewardOverriddenEnv(env, f)
+
+Apply `f` on `reward(env)`.
+"""
 struct RewardOverriddenEnv{F,E<:AbstractEnv} <: AbstractEnvWrapper
     env::E
     f::F

--- a/src/environments/wrappers/StateOverriddenEnv.jl
+++ b/src/environments/wrappers/StateOverriddenEnv.jl
@@ -1,20 +1,25 @@
 export StateOverriddenEnv
 
 """
-    StateOverriddenEnv(f, env)
+    StateOverriddenEnv(env; state_mapping=identity, state_space_mapping=identity)
 
-Apply `f` to override `state(env)`.
-
-!!! note
-    If the meaning of state space is changed after apply `f`, one should
-    manually redefine the `RLBase.state_space(env::YourSpecificEnv)`.
+Apply `state_mapping` on `state(env)`.
+Apply `state_space_mapping` on `state_space(env)`.
 """
-struct StateOverriddenEnv{F,E<:AbstractEnv} <: AbstractEnvWrapper
+struct StateOverriddenEnv{P,M,E<:AbstractEnv} <: AbstractEnvWrapper
+    state_mapping::P
+    state_space_mapping::M
     env::E
-    f::F
 end
 
-StateOverriddenEnv(f) = env -> StateOverriddenEnv(f, env)
+StateOverriddenEnv(env; state_mapping=identity, state_space_mapping=identity) = 
+    StateOverriddenEnv(state_mapping, state_space_mapping, env)
+
+StateOverriddenEnv(; state_mapping=identity, state_space_mapping=identity) = 
+    env -> StateOverriddenEnv(state_mapping, state_space_mapping, env)
 
 RLBase.state(env::StateOverriddenEnv, args...; kwargs...) =
-    env.f(state(env.env, args...; kwargs...))
+    env.state_mapping(state(env.env, args...; kwargs...))
+
+RLBase.state_space(env::StateOverriddenEnv, args...; kwargs...) = 
+    env.state_space_mapping(state_space(env.env, args...; kwargs...))


### PR DESCRIPTION
Just noticed some inconsistencies in the wrapper interfaces and thought I would have a look at them.

One thing that some wrappers had was a method for creating an easily chainable creator method, and I found it missing in some of them.
```julia
SomeWrapper(;arg) = env -> SomeWrapper(env, arg)
# Allows for 
YourEnv(args) |> SomeWrapper(;arg)
```

One other thing I thought about was the naming, for example `ActionTransformedEnv` compared to `StateOverriddenEnv`. Why is one transformed and one overridden? I don't have any strong opinions here, just found it slightly odd.

Also for action we could override both action and action_space, while for state it gave instructions in the docstring that if the state space would change you should reimplement it. Seems like they should probably use the same structure for both?